### PR TITLE
Fix for case where a markdown list is in code blk

### DIFF
--- a/el2markdown.el
+++ b/el2markdown.el
@@ -279,7 +279,7 @@ things in comments.")
         (terpri)))))
 
 
-(defun el2markdown-convert-formal-information-item (item lim &optional link)
+(defun el2markdown-convert-formal-information-item (item _lim &optional link)
   (when (re-search-forward (concat "^;;+ " item ": *\\(.*\\)") nil t)
     (let ((s (match-string-no-properties 1)))
       (if link
@@ -318,12 +318,17 @@ things in comments.")
   (terpri)
   (terpri))
 
+(defun el2markdown-is-in-code ()
+  "Return non-nil if point is considered to be in a code block."
+  (or (looking-at ";;+ *(")
+      (looking-at ";;+\\s-\\{5,\\}")))
 
 (defun el2markdown-is-at-bullet-list ()
   (save-excursion
     (while (looking-at "^;;$")
       (forward-line))
-    (looking-at ";;+ *[-*]")))
+    (and (not (el2markdown-is-in-code))
+         (looking-at ";;+ *[-*]"))))
 
 (defun el2markdown-emit-rest-of-comment ()
   (let ((first t))
@@ -345,8 +350,7 @@ things in comments.")
                             (while (looking-at el2markdown-empty-comment)
                               (forward-line))
                             (or (el2markdown-is-at-bullet-list)
-                                (looking-at ";;+ *(")
-                                (looking-at ";;+     ")))))))
+                                (el2markdown-is-in-code)))))))
           ;; Header
           (progn
             (el2markdown-emit-header (if first 2 3)


### PR DESCRIPTION
Here is the example code block in a .el file:

``` el
;;     * Heading 1
;;       + Sub heading
;;         - More nesting
;;           - List item 1
;;           - List item 2
;;           - List item 3
;;
;;     * Heading 2
;;       + Sub heading
;;         - List item 1
;;         - List item 2
;;         - List item 3
;;         - More nesting
```

Earlier the markdown conversion of that gave:

``` md
    * Heading 1
      + Sub heading
        - More nesting
          - List item 1
          - List item 2
          - List item 3
    * Heading 2
      + Sub heading
        - List item 1
        - List item 2
        - List item 3
        - More nesting
```

Now we get:

``` md
    * Heading 1
      + Sub heading
        - More nesting
          - List item 1
          - List item 2
          - List item 3

    * Heading 2
      + Sub heading
        - List item 1
        - List item 2
        - List item 3
        - More nesting
```

Note that now we do not lose that empty line above "\* Heading 2".
